### PR TITLE
修复ClashPro规则组中的“国际媒体”图标失效

### DIFF
--- a/Clash/ClashPro/tickmao-pro.yml
+++ b/Clash/ClashPro/tickmao-pro.yml
@@ -232,7 +232,7 @@ proxy-groups:
 
   - {name: 国外网站, <<: *pg, icon: https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Global.png}
 
-  - {name: 国际媒体, <<: *pg, icon: https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Youtube.png}
+  - {name: 国际媒体, <<: *pg, icon: https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/YouTube.png}
 
   - {name: 苹果服务, <<: *pg, icon: https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Apple.png}
 

--- a/Clash/ClashPro/tickmao-pro.yml
+++ b/Clash/ClashPro/tickmao-pro.yml
@@ -220,7 +220,10 @@ proxies:
 
 proxy-providers:
 
-  # Subscribe: {<<: *p, path: ./proxy-providers/Sub.yaml, url: http://your-service-provider}
+#    Subscribe: 
+#      <<: *p
+#      path: ./proxy-providers/Sub.yaml
+#      url: http://your-service-provider
     # 在此将"http://your-service-provider"替换为你的机场订阅，推荐使用 base64 或者 node list
     # Sub-Store生成的链接,可以直接替换上述 url 引号中的部分,具体见 Sub-Store 教程  
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 ## 各平台配置
 
-* QuantumultX 配置：[tickmao.conf](https://raw.githubusercontent.com/tickmao/Rules/master/QuantumultX/tickmao.conf)
+* QuantumultX 配置：[tickmao.conf](https://raw.githubusercontent.com/AlexMa2011/Clash_Rules_fork/master/QuantumultX/tickmao.conf)
 
-* Surge配置：[tickmao.conf](https://raw.githubusercontent.com/tickmao/Rules/master/Surge/tickmao.conf)
+* Surge配置：[tickmao.conf](https://raw.githubusercontent.com/AlexMa2011/Clash_Rules_fork/master/Surge/tickmao.conf)
 
-* Loon配置：[tickmao.conf](https://raw.githubusercontent.com/tickmao/Rules/master/Loon/tickmao.conf)
+* Loon配置：[tickmao.conf](https://raw.githubusercontent.com/AlexMa2011/Clash_Rules_fork/master/Loon/tickmao.conf)
 
-* Clash Verge rev 配置：[tickmao-pro.yml](https://raw.githubusercontent.com/tickmao/Rules/master/Clash/ClashPro/tickmao-pro.yml)
+* Clash Verge rev 配置：[tickmao-pro.yml](https://raw.githubusercontent.com/AlexMa2011/Clash_Rules_fork/master/Clash/ClashPro/tickmao-pro.yml)
 
-* Clash for windows 配置：[tickmao.yml](https://raw.githubusercontent.com/tickmao/Rules/master/Clash/Clash/tickmao.yml)
+* Clash for windows 配置：[tickmao.yml](https://raw.githubusercontent.com/AlexMa2011/Clash_Rules_fork/master/Clash/Clash/tickmao.yml)
 
-* Shadowrocket 配置: [tickmao.conf](https://raw.githubusercontent.com/tickmao/Rules/master/Shadowrocket/tickmao.conf)
+* Shadowrocket 配置: [tickmao.conf](https://raw.githubusercontent.com/AlexMa2011/Clash_Rules_fork/master/Shadowrocket/tickmao.conf)
 
 ## 参与我们
 


### PR DESCRIPTION
将https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Youtube.png 
替换为
https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Youtube.png